### PR TITLE
Add "command" from Google in payload

### DIFF
--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -365,7 +365,11 @@ class HttpActions {
             id: device.id,
             states: {},
         };
-
+        
+        if (command.hasOwnProperty('command')) {
+			curDevice.states['command'] = command.command;
+		}
+        
         if (command.hasOwnProperty('params')) {
             Object.keys(command.params).forEach(function (key) {
                 // arrgggghhhh - why Google, why ...


### PR DESCRIPTION
For vacuum is mandatory for locator, dock, etc... maybe for other device